### PR TITLE
warm up period and slashable

### DIFF
--- a/EIPS/eip-1011.md
+++ b/EIPS/eip-1011.md
@@ -53,6 +53,7 @@ The Casper FFG contract can be layered on top of any block proposal mechanism, p
 * `NEW_BLOCK_REWARD`: 6e17 wei (0.6 ETH)
 * `REWARD_STEPDOWN_BLOCK_COUNT`: 5.5e5 blocks (~3 months)
 * `CASPER_INIT_DATA`: TBD
+* `VOTE_BYTES`: `0xe9dc0614`
 * `INITIALIZE_EPOCH_BYTES`: `0x5dcffc17`
 * `NON_REVERT_MIN_DEPOSIT`: amount in wei configurable by client
 
@@ -105,6 +106,11 @@ If `block.number >= (HYBRID_CASPER_FORK_BLKNUM + WARM_UP_PERIOD)` and `block.num
 This `CALL` utilizes no gas and does not increment the nonce of `NULL_SENDER`
 
 #### Casper Votes
+
+A `vote` transaction is defined as a transaction with the follow parameters:
+
+* `TO`: `CASPER_ADDR`
+* `DATA`: Begins with `VOTE_BYTES`
 
 If `block.number >= HYBRID_CASPER_FORK_BLKNUM`, then:
 

--- a/EIPS/eip-1011.md
+++ b/EIPS/eip-1011.md
@@ -59,7 +59,8 @@ The Casper FFG contract can be layered on top of any block proposal mechanism, p
 ### Casper Contract Parameters
 
 * `EPOCH_LENGTH`: 50 blocks
-* `WITHDRAWAL_DELAY`: 15,000 epochs
+* `WARM_UP_PERIOD`: 1.8e5 blocks (~1 month)
+* `WITHDRAWAL_DELAY`: 1.5e4 epochs
 * `DYNASTY_LOGOUT_DELAY`: 700 dynasties
 * `BASE_INTEREST_FACTOR`: 7e-3
 * `BASE_PENALTY_FACTOR`: 2e-7
@@ -91,7 +92,7 @@ This `CALL` utilizes no gas and does not increment the nonce of `NULL_SENDER`
 
 #### Initialize Epochs
 
-If `block.number >= HYBRID_CASPER_FORK_BLKNUM` and `block.number % EPOCH_LENGTH == 0`, execute a `CALL` with the following parameters before executing any normal block transactions:
+If `block.number >= (HYBRID_CASPER_FORK_BLKNUM + WARM_UP_PERIOD)` and `block.number % EPOCH_LENGTH == 0`, execute a `CALL` with the following parameters before executing any normal block transactions:
 
 * `SENDER`: `NULL_SENDER`
 * `GAS`: 3141592
@@ -347,11 +348,11 @@ The `MSG_HASHER_CODE` and `PURITY_CHECKER_CODE` both do not require any initiali
 
 The entirety of this data is provided as a bytestring -- `CASPER_INIT_DATA` -- to reduce the chance of encoding errors across clients, especially regarding fixed decimal types which are new in vyper and not yet supported by all clients.
 
-It should be noted that `HYBRID_CASPER_FORK_BLKNUM % EPOCH_LENGTH == 0` to ensure that the initial epoch is initialized immediately after contract initialization and before any block transactions are processed.
-
 #### Casper Contract Params
 
 `EPOCH_LENGTH` is set to 50 blocks as a balance between time to finality and message overhead.
+
+`WARM_UP_PERIOD` is set to 1.8e5 blocks to provide validators with an approximate 1 month period to make initial deposits before full contract functionality and voting begin. This helps prevent degenerate cases such as having very few or even just one validator in the initial dynasty. This 1 month period also gives the network time to observe on the order of how many validators will initially be participating in consensus. If for some reason there is an unexpectedly low turnout, the community might choose to delay validation and consider design alternatives.
 
 `WITHDRAWAL_DELAY` is set to 15000 epochs to freeze a validator's funds for approximately 4 months after logout. This allows for at least a 4 month window to identify and slash a validator for attempting to finalize two conflicting checkpoints. This also defines the window of time with which a client must log on to sync the network due to weak subjectivity.
 
@@ -364,7 +365,9 @@ It should be noted that `HYBRID_CASPER_FORK_BLKNUM % EPOCH_LENGTH == 0` to ensur
 `MIN_DEPOSIT_SIZE` is set to 1500 ETH to form a natural upper bound on the total number of validators, bounding the overhead due to `vote` messages. Using formulas found [here](https://medium.com/@VitalikButerin/parametrizing-casper-the-decentralization-finality-time-overhead-tradeoff-3f2011672735) under "From validator count to minimum staking ETH", we estimate that with 1500 ETH minimum deposit at an assumed ~10M in total deposits there will be approximately 900 validators at any given time. `vote`s are only sent after the first quarter of an epoch so 900 votes have to fit into 37 blocks or ~24 `vote`s per block. We have experimented with more dynamic models for `MIN_DEPOSIT_SIZE`, but these tend to introduce significant complexities and without data from a live network seem to be premature optimizations.
 
 #### Initialize Epochs
-The call to the method at `INITIALIZE_EPOCH_BYTES` at `CASPER_ADDR` at the start of each epoch is a call to the `initialize_epoch` method in the casper contract. This method can only be called once per epoch and is garaunteed by the protocol to be called at the start block of each epoch by `NULL_SENDER`. This method performs a number of bookkeeping tasks around incrementing variables, updating rewards, etc.
+The call to the method at `INITIALIZE_EPOCH_BYTES` at `CASPER_ADDR` at the start of each epoch is a call to the `initialize_epoch` method in the casper contract. This method can only be called once per epoch and is guaranteed by the protocol to be called at the start block of each epoch by `NULL_SENDER`. This method performs a number of bookkeeping tasks around incrementing variables, updating rewards, etc.
+
+Any call to this method fails prior to the end of the `WARM_UP_PERIOD`. Thus the protocol does not begin executing `initialize_epoch` calls until `block.number >= HYBRID_CASPER_FORK_BLKNUM + WARM_UP_PERIOD`.
 
 #### Issuance
 A fixed amount of 1.25M ETH was chosen as `CASPER_BALANCE` to fund the casper contract. This gives the contract enough runway to operate for approximately 2 years (assuming ~10M ETH in validator deposits). Acting similarly to the "difficulty bomb", this "funding crunch" forces the network to hardfork in the relative near future to further fund the contract. This future hardfork is an opportunity to upgrade the contract and transition to full PoS.

--- a/EIPS/eip-1011.md
+++ b/EIPS/eip-1011.md
@@ -319,9 +319,10 @@ def surrounds(vote_msg_1, vote_msg_2):
 def violates_slashing_condition(vote_msg_1, vote_msg_2):
     return same_target_epoch(vote_msg_1, vote_msg_2) or surrounds(vote_msg_1, vote_msg_2)
 ```
-This setting is to be used for clients that wish to monitor vote transactions for slashing conditions. If a slashing condition is found, the client creates and sends a transaction to `slash` on the casper contract. The first transaction to include the slashing condition proof slashes the validator in question and sends a 4% finder's fee to the transaction sender.
 
-Suggested default disabled. Block producers would be the most likely to want to enable this flag as they are likely to frontrun anyone else that submit the slashing tx to grab the reward. Because block producers are likely to front-run, others would probably leave off so they don't submit a tx that will be included, cost them gas, but be too late to get the reward
+The casper contract also provides a helper method `slashable(vote_msg_1, vote_msg_2)` to check if two votes violate a slashing condition. Clients should use the above pseudocode in combination with `casper.slashable()` as a final check when deciding whether to submit a `slash` to the contract.
+
+The `--monitor-votes` setting is to be used for clients that wish to monitor vote transactions for slashing conditions. If a slashing condition is found, the client creates and sends a transaction to `slash` on the casper contract. The first transaction to include the slashing condition proof slashes the validator in question and sends a 4% finder's fee to the transaction sender.
 
 ## Rationale
 


### PR DESCRIPTION
- add `WARM_UP_PERIOD` param
- clients not to call `initialize_epoch` until `block.number >= WARM_UP_PERIOD`
- Add warm up period rationale
- Add `slashable` to `--monitor-votes` encouraging clients to the use the pseudocode in conjunction with `slashable` as a final check.

recently added
- `VOTE_BYTES` param
- Definition of `vote` transaction defined by `TO` and `DATA` prefix